### PR TITLE
feat(nvs,wifi): Phase 2 — NVS storage and WiFi manager

### DIFF
--- a/components/nvs_storage/Kconfig
+++ b/components/nvs_storage/Kconfig
@@ -1,0 +1,9 @@
+menu "SmartVault Configuration"
+
+    config API_BASE_URL
+        string "API Base URL"
+        default "http://localhost:3000"
+        help
+            The base URL of the SmartVault API. Can be overridden at runtime via provisioning portal.
+
+endmenu

--- a/components/nvs_storage/include/nvs_storage.h
+++ b/components/nvs_storage/include/nvs_storage.h
@@ -1,4 +1,30 @@
 #pragma once
 
-// NVS Storage module
-// TODO: declare public API
+#include <stdbool.h>
+#include "esp_err.h"
+
+esp_err_t nvs_storage_init(void);
+
+// WiFi credentials
+esp_err_t nvs_storage_save_wifi(const char *ssid, const char *password);
+esp_err_t nvs_storage_load_wifi(char *ssid, size_t ssid_len, char *password, size_t pass_len);
+
+// Provisioned flag
+esp_err_t nvs_storage_set_provisioned(bool provisioned);
+bool nvs_storage_is_provisioned(void);
+
+// Hardware UUID
+esp_err_t nvs_storage_save_hardware_uuid(const char *uuid);
+esp_err_t nvs_storage_load_hardware_uuid(char *uuid, size_t len);
+
+// API base URL (optional override)
+esp_err_t nvs_storage_save_api_url(const char *url);
+esp_err_t nvs_storage_load_api_url(char *url, size_t len);
+
+// NFC card UID (provisioning card)
+esp_err_t nvs_storage_save_nfc_uid(const char *uid);
+esp_err_t nvs_storage_load_nfc_uid(char *uid, size_t len);
+
+// Provisioning token
+esp_err_t nvs_storage_save_provisioning_token(const char *token);
+esp_err_t nvs_storage_load_provisioning_token(char *token, size_t len);

--- a/components/nvs_storage/nvs_storage.c
+++ b/components/nvs_storage/nvs_storage.c
@@ -1,6 +1,140 @@
 #include "nvs_storage.h"
+#include "nvs_flash.h"
+#include "nvs.h"
 #include "esp_log.h"
+#include <string.h>
 
 static const char *TAG = "NVS_STORAGE";
+#define NVS_NAMESPACE "smrtvlt"
 
-// TODO: implement nvs_storage module
+esp_err_t nvs_storage_init(void) {
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_LOGW(TAG, "NVS partition truncated, erasing...");
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    ESP_LOGI(TAG, "NVS initialized");
+    return ret;
+}
+
+esp_err_t nvs_storage_save_wifi(const char *ssid, const char *password) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) return ret;
+    nvs_set_str(handle, "wifi_ssid", ssid);
+    nvs_set_str(handle, "wifi_pass", password);
+    ret = nvs_commit(handle);
+    nvs_close(handle);
+    ESP_LOGI(TAG, "WiFi credentials saved");
+    return ret;
+}
+
+esp_err_t nvs_storage_load_wifi(char *ssid, size_t ssid_len, char *password, size_t pass_len) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle);
+    if (ret != ESP_OK) return ret;
+    nvs_get_str(handle, "wifi_ssid", ssid, &ssid_len);
+    nvs_get_str(handle, "wifi_pass", password, &pass_len);
+    nvs_close(handle);
+    return ESP_OK;
+}
+
+esp_err_t nvs_storage_set_provisioned(bool provisioned) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) return ret;
+    nvs_set_u8(handle, "provisioned", provisioned ? 1 : 0);
+    ret = nvs_commit(handle);
+    nvs_close(handle);
+    return ret;
+}
+
+bool nvs_storage_is_provisioned(void) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle);
+    if (ret != ESP_OK) return false;
+    uint8_t val = 0;
+    nvs_get_u8(handle, "provisioned", &val);
+    nvs_close(handle);
+    return val == 1;
+}
+
+esp_err_t nvs_storage_save_hardware_uuid(const char *uuid) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) return ret;
+    nvs_set_str(handle, "hw_uuid", uuid);
+    ret = nvs_commit(handle);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t nvs_storage_load_hardware_uuid(char *uuid, size_t len) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle);
+    if (ret != ESP_OK) return ret;
+    nvs_get_str(handle, "hw_uuid", uuid, &len);
+    nvs_close(handle);
+    return ESP_OK;
+}
+
+esp_err_t nvs_storage_save_api_url(const char *url) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) return ret;
+    nvs_set_str(handle, "api_url", url);
+    ret = nvs_commit(handle);
+    nvs_close(handle);
+    ESP_LOGI(TAG, "API URL saved: %s", url);
+    return ret;
+}
+
+esp_err_t nvs_storage_load_api_url(char *url, size_t len) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle);
+    if (ret != ESP_OK) return ret;
+    ret = nvs_get_str(handle, "api_url", url, &len);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t nvs_storage_save_nfc_uid(const char *uid) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) return ret;
+    nvs_set_str(handle, "nfc_uid", uid);
+    ret = nvs_commit(handle);
+    nvs_close(handle);
+    ESP_LOGI(TAG, "NFC UID saved: %s", uid);
+    return ret;
+}
+
+esp_err_t nvs_storage_load_nfc_uid(char *uid, size_t len) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle);
+    if (ret != ESP_OK) return ret;
+    ret = nvs_get_str(handle, "nfc_uid", uid, &len);
+    nvs_close(handle);
+    return ret;
+}
+
+esp_err_t nvs_storage_save_provisioning_token(const char *token) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) return ret;
+    nvs_set_str(handle, "prov_token", token);
+    ret = nvs_commit(handle);
+    nvs_close(handle);
+    ESP_LOGI(TAG, "Provisioning token saved");
+    return ret;
+}
+
+esp_err_t nvs_storage_load_provisioning_token(char *token, size_t len) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle);
+    if (ret != ESP_OK) return ret;
+    ret = nvs_get_str(handle, "prov_token", token, &len);
+    nvs_close(handle);
+    return ret;
+}

--- a/components/wifi_manager/include/wifi_manager.h
+++ b/components/wifi_manager/include/wifi_manager.h
@@ -1,4 +1,9 @@
 #pragma once
 
-// WiFi Manager module
-// TODO: declare public API
+#include "esp_err.h"
+#include <stdbool.h>
+
+esp_err_t wifi_manager_init(void);
+esp_err_t wifi_manager_connect(const char *ssid, const char *password);
+bool wifi_manager_is_connected(void);
+void wifi_manager_disconnect(void);

--- a/components/wifi_manager/wifi_manager.c
+++ b/components/wifi_manager/wifi_manager.c
@@ -1,6 +1,116 @@
 #include "wifi_manager.h"
+#include "esp_wifi.h"
+#include "esp_event.h"
+#include "esp_netif.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include <string.h>
 
 static const char *TAG = "WIFI_MANAGER";
 
-// TODO: implement wifi_manager module
+#define WIFI_CONNECTED_BIT BIT0
+#define WIFI_FAIL_BIT      BIT1
+#define WIFI_MAX_RETRY     5
+
+static EventGroupHandle_t s_wifi_event_group;
+static int s_retry_num = 0;
+static bool s_connected = false;
+static bool s_initialized = false;
+
+static void wifi_event_handler(void *arg, esp_event_base_t event_base,
+                               int32_t event_id, void *event_data) {
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        s_connected = false;
+        if (s_retry_num < WIFI_MAX_RETRY) {
+            esp_wifi_connect();
+            s_retry_num++;
+            ESP_LOGI(TAG, "Retrying WiFi connection (%d/%d)...", s_retry_num, WIFI_MAX_RETRY);
+        } else {
+            xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
+            ESP_LOGE(TAG, "WiFi connection failed after %d retries", WIFI_MAX_RETRY);
+        }
+    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
+        ESP_LOGI(TAG, "Got IP: " IPSTR, IP2STR(&event->ip_info.ip));
+        s_retry_num = 0;
+        s_connected = true;
+        xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+    }
+}
+
+esp_err_t wifi_manager_init(void) {
+    if (s_initialized) {
+        return ESP_OK;
+    }
+
+    s_wifi_event_group = xEventGroupCreate();
+
+    esp_err_t ret = esp_netif_init();
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+        return ret;
+    }
+
+    ret = esp_event_loop_create_default();
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+        return ret;
+    }
+
+    if (esp_netif_get_handle_from_ifkey("WIFI_STA_DEF") == NULL) {
+        esp_netif_create_default_wifi_sta();
+    }
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ret = esp_wifi_init(&cfg);
+    if (ret != ESP_OK && ret != ESP_ERR_WIFI_INIT_STATE) {
+        return ret;
+    }
+
+    esp_event_handler_instance_t instance_any_id;
+    esp_event_handler_instance_t instance_got_ip;
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
+                                                        &wifi_event_handler, NULL, &instance_any_id));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_GOT_IP,
+                                                        &wifi_event_handler, NULL, &instance_got_ip));
+
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    s_initialized = true;
+    ESP_LOGI(TAG, "WiFi manager initialized");
+    return ESP_OK;
+}
+
+esp_err_t wifi_manager_connect(const char *ssid, const char *password) {
+    wifi_config_t wifi_config = {0};
+    strncpy((char *)wifi_config.sta.ssid, ssid, sizeof(wifi_config.sta.ssid) - 1);
+    strncpy((char *)wifi_config.sta.password, password, sizeof(wifi_config.sta.password) - 1);
+    wifi_config.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
+
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+    ESP_ERROR_CHECK(esp_wifi_start());
+    ESP_ERROR_CHECK(esp_wifi_connect());
+
+    ESP_LOGI(TAG, "Connecting to SSID: %s", ssid);
+
+    EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group,
+                                           WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+                                           pdFALSE, pdFALSE, pdMS_TO_TICKS(15000));
+
+    if (bits & WIFI_CONNECTED_BIT) {
+        ESP_LOGI(TAG, "Connected to WiFi");
+        return ESP_OK;
+    } else {
+        ESP_LOGE(TAG, "Failed to connect to WiFi");
+        return ESP_FAIL;
+    }
+}
+
+bool wifi_manager_is_connected(void) {
+    return s_connected;
+}
+
+void wifi_manager_disconnect(void) {
+    esp_wifi_disconnect();
+    esp_wifi_stop();
+    s_connected = false;
+    ESP_LOGI(TAG, "WiFi disconnected");
+}


### PR DESCRIPTION
## Summary
Implements NVS persistence layer and WiFi manager module.

## Type
- [x] `feat` — new feature

## Component(s) Affected
`nvs_storage`, `wifi_manager`

## Related Phase
Phase 2 — NVS + WiFi

## Changes
- Implement `nvs_storage` module: save/load WiFi creds, provisioned flag, hardware UUID, API URL, NFC UID, provisioning token
- Add `Kconfig` with `CONFIG_API_BASE_URL` default (`http://localhost:3000`)
- Implement `wifi_manager` module: connect, auto-retry on disconnect (max 5), event-driven

## Testing
- [x] Built successfully (`idf.py build`)
- [ ] Tested on real ESP32 hardware
- [ ] Relevant section in `HARDWARE_TESTS.md` checked off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WiFi connectivity management with automatic connection handling, retry logic, and real-time connection status monitoring
  * Persistent configuration storage for WiFi credentials, hardware identifiers, and API endpoint settings
  * Device provisioning capabilities with full support for provisioning tokens and state tracking
  * Configurable SmartVault API endpoint with customizable base URL option for runtime override

<!-- end of auto-generated comment: release notes by coderabbit.ai -->