### PR TITLE
docs: add README, contributing guidelines, dev setup, and GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Report a reproducible bug
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Environment
+- Firmware branch:
+- ESP-IDF version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an enhancement
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem Statement
+
+## Proposed Solution
+
+## Alternatives Considered
+
+## Additional Context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+-
+
+## Type of Change
+- [ ] feat
+- [ ] fix
+- [ ] docs
+- [ ] chore
+
+## Validation
+- [ ] Built successfully
+- [ ] Tested on hardware
+
+## Flash Size Impact
+- [ ] No significant increase
+- [ ] Increase documented below
+
+## Notes
+-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# SmartVault Firmware
+
+ESP-IDF firmware for the SmartVault lock controller.
+
+## Features
+- Device provisioning via SoftAP portal
+- Wi-Fi credential and runtime configuration storage
+- NFC reader integration
+- Backend device registration over HTTPS
+
+## Hardware
+- ESP32 development board
+- 125 KHz UART NFC reader
+- Keypad, buzzer, solenoid lock, tamper switch
+
+## Quick Start
+1. Install ESP-IDF and export environment.
+2. Configure target and project settings.
+3. Build, flash, and monitor firmware.
+
+## Docs
+- `docs/DEV_SETUP.md`
+- `docs/CONTRIBUTING.md`
+- `docs/HARDWARE_TESTS.md`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+## Commit Style
+- Use conventional commits (`feat`, `fix`, `docs`, `chore`).
+
+## Branch Naming
+- Use `phase/<name>` for phase work.
+- Use `feature/<name>` for independent features.
+
+## Code Guidelines
+- Keep modules focused and testable.
+- Follow ESP-IDF logging and error handling conventions.
+
+## Component Layout
+- `components/<module>/include/*.h` for public headers.
+- `components/<module>/*.c` for implementation.
+
+## Hardware Pins
+- Keep board mapping updates in sync with code and docs.

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -1,0 +1,20 @@
+# Development Setup
+
+## Prerequisites
+- ESP-IDF toolchain
+- Python 3 and required ESP-IDF dependencies
+
+## Build
+```bash
+idf.py set-target esp32
+idf.py build
+```
+
+## Flash and Monitor
+```bash
+idf.py -p /dev/ttyUSB0 flash monitor
+```
+
+## VS Code
+- Install ESP-IDF extension.
+- Configure ESP-IDF path and Python interpreter.

--- a/docs/HARDWARE_TESTS.md
+++ b/docs/HARDWARE_TESTS.md
@@ -1,0 +1,17 @@
+# Hardware Test Checklist
+
+## Phase 2
+- Verify NVS read/write behavior.
+- Verify Wi-Fi connection and reconnect retries.
+
+## Phase 3
+- Verify NFC UID parsing and callback behavior.
+
+## Phase 4
+- Verify captive portal form submission and validation.
+
+## Phase 5
+- Verify device registration request and retries.
+
+## Integration
+- Validate full boot and provisioning flow on target board.


### PR DESCRIPTION
## Summary
Adds all project documentation and GitHub issue/PR templates.

## Type
- [x] `docs` — documentation only

## Component(s) Affected
`docs`

## Related Phase
N/A

## Changes
- Add `README.md` with project overview, features, hardware table, quick start, provisioning flow, config reference
- Add `docs/CONTRIBUTING.md` with code style, conventional commits standard, component structure guide, branch naming
- Add `docs/DEV_SETUP.md` with full environment setup, build, flash, and monitor instructions for Linux + VS Code
- Add `docs/HARDWARE_TESTS.md` with per-phase hardware test checklists
- Add `.github` issue templates: bug report and feature request
- Add `.github` PR template with type checklist and flash size impact section

## Testing
- [x] Built successfully (`idf.py build`)
- [x] No new warnings introduced