### PR TITLE
feat(keypad,pin_auth,solenoid,buzzer): Phase 6 - keypad PIN auth and vault unlock

### DIFF
--- a/components/buzzer/CMakeLists.txt
+++ b/components/buzzer/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "buzzer.c"
     INCLUDE_DIRS "include"
-    REQUIRES driver
+    REQUIRES driver freertos
 )

--- a/components/buzzer/buzzer.c
+++ b/components/buzzer/buzzer.c
@@ -1,6 +1,46 @@
 #include "buzzer.h"
+#include "driver/gpio.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 static const char *TAG = "BUZZER";
 
-// TODO: implement buzzer module
+esp_err_t buzzer_init(void)
+{
+    gpio_config_t io_conf = {
+        .pin_bit_mask = (1ULL << BUZZER_GPIO),
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    esp_err_t ret = gpio_config(&io_conf);
+    if (ret != ESP_OK) return ret;
+    gpio_set_level(BUZZER_GPIO, 0);
+    ESP_LOGI(TAG, "Buzzer initialized (GPIO%d)", BUZZER_GPIO);
+    return ESP_OK;
+}
+
+esp_err_t buzzer_beep_short(void)
+{
+    gpio_set_level(BUZZER_GPIO, 1);
+    vTaskDelay(pdMS_TO_TICKS(200));
+    gpio_set_level(BUZZER_GPIO, 0);
+    ESP_LOGI(TAG, "Short beep");
+    return ESP_OK;
+}
+
+esp_err_t buzzer_alarm_start(void)
+{
+    gpio_set_level(BUZZER_GPIO, 1);
+    ESP_LOGI(TAG, "Alarm started");
+    return ESP_OK;
+}
+
+esp_err_t buzzer_alarm_stop(void)
+{
+    gpio_set_level(BUZZER_GPIO, 0);
+    ESP_LOGI(TAG, "Alarm stopped");
+    return ESP_OK;
+}

--- a/components/buzzer/include/buzzer.h
+++ b/components/buzzer/include/buzzer.h
@@ -1,4 +1,10 @@
 #pragma once
 
-// Buzzer module
-// TODO: declare public API
+#include "esp_err.h"
+
+#define BUZZER_GPIO 12
+
+esp_err_t buzzer_init(void);
+esp_err_t buzzer_beep_short(void);
+esp_err_t buzzer_alarm_start(void);
+esp_err_t buzzer_alarm_stop(void);

--- a/components/keypad/include/keypad.h
+++ b/components/keypad/include/keypad.h
@@ -1,4 +1,13 @@
 #pragma once
+#include "esp_err.h"
+#include <stdint.h>
 
-// Keypad module
-// TODO: declare public API
+#define KEYPAD_MAX_PIN_LEN  8
+#define KEYPAD_TIMEOUT_MS   10000
+
+typedef void (*keypad_pin_callback_t)(const char *pin);
+
+esp_err_t keypad_init(void);
+esp_err_t keypad_start(keypad_pin_callback_t callback);
+void keypad_stop(void);
+char keypad_scan(void);

--- a/components/keypad/keypad.c
+++ b/components/keypad/keypad.c
@@ -1,6 +1,140 @@
 #include "keypad.h"
+#include "driver/gpio.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include <string.h>
 
 static const char *TAG = "KEYPAD";
 
-// TODO: implement keypad module
+static const gpio_num_t ROW_PINS[4] = {GPIO_NUM_21, GPIO_NUM_22, GPIO_NUM_23, GPIO_NUM_25};
+static const gpio_num_t COL_PINS[3] = {GPIO_NUM_26, GPIO_NUM_27, GPIO_NUM_32};
+
+static const char KEY_MAP[4][3] = {
+    {'1', '2', '3'},
+    {'4', '5', '6'},
+    {'7', '8', '9'},
+    {'*', '0', '#'}
+};
+
+static keypad_pin_callback_t s_callback = NULL;
+static TaskHandle_t s_task_handle = NULL;
+
+esp_err_t keypad_init(void)
+{
+    for (int i = 0; i < 4; i++) {
+        gpio_config_t io_conf = {
+            .pin_bit_mask = (1ULL << ROW_PINS[i]),
+            .mode = GPIO_MODE_OUTPUT,
+            .pull_up_en = GPIO_PULLUP_DISABLE,
+            .pull_down_en = GPIO_PULLDOWN_DISABLE,
+            .intr_type = GPIO_INTR_DISABLE,
+        };
+        gpio_config(&io_conf);
+        gpio_set_level(ROW_PINS[i], 1);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        gpio_config_t io_conf = {
+            .pin_bit_mask = (1ULL << COL_PINS[i]),
+            .mode = GPIO_MODE_INPUT,
+            .pull_up_en = GPIO_PULLUP_ENABLE,
+            .pull_down_en = GPIO_PULLDOWN_DISABLE,
+            .intr_type = GPIO_INTR_DISABLE,
+        };
+        gpio_config(&io_conf);
+    }
+
+    ESP_LOGI(TAG, "Keypad initialized");
+    return ESP_OK;
+}
+
+char keypad_scan(void)
+{
+    for (int row = 0; row < 4; row++) {
+        gpio_set_level(ROW_PINS[row], 0);
+        vTaskDelay(pdMS_TO_TICKS(5));
+
+        for (int col = 0; col < 3; col++) {
+            if (gpio_get_level(COL_PINS[col]) == 0) {
+                while (gpio_get_level(COL_PINS[col]) == 0) {
+                    vTaskDelay(pdMS_TO_TICKS(10));
+                }
+                gpio_set_level(ROW_PINS[row], 1);
+                return KEY_MAP[row][col];
+            }
+        }
+
+        gpio_set_level(ROW_PINS[row], 1);
+    }
+    return 0;
+}
+
+static void keypad_task(void *arg)
+{
+    (void)arg;
+    char pin_buf[KEYPAD_MAX_PIN_LEN + 1] = {0};
+    int pin_len = 0;
+    TickType_t last_key_tick = xTaskGetTickCount();
+
+    ESP_LOGI(TAG, "Keypad listener started. Enter PIN and press #");
+
+    while (1) {
+        char key = keypad_scan();
+
+        if (key != 0) {
+            last_key_tick = xTaskGetTickCount();
+
+            if (key == '#') {
+                if (pin_len > 0) {
+                    pin_buf[pin_len] = '\0';
+                    ESP_LOGI(TAG, "PIN submitted (len=%d)", pin_len);
+                    if (s_callback) {
+                        s_callback(pin_buf);
+                    }
+                    memset(pin_buf, 0, sizeof(pin_buf));
+                    pin_len = 0;
+                }
+            } else if (key == '*') {
+                memset(pin_buf, 0, sizeof(pin_buf));
+                pin_len = 0;
+                ESP_LOGI(TAG, "PIN cleared");
+            } else if (pin_len < KEYPAD_MAX_PIN_LEN) {
+                pin_buf[pin_len++] = key;
+                ESP_LOGI(TAG, "Key: %c (%d/%d)", key, pin_len, KEYPAD_MAX_PIN_LEN);
+            } else {
+                ESP_LOGW(TAG, "PIN buffer full");
+            }
+        }
+
+        TickType_t now = xTaskGetTickCount();
+        if (pin_len > 0 && (now - last_key_tick) > pdMS_TO_TICKS(KEYPAD_TIMEOUT_MS)) {
+            ESP_LOGW(TAG, "PIN timeout, clearing");
+            memset(pin_buf, 0, sizeof(pin_buf));
+            pin_len = 0;
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(50));
+    }
+}
+
+esp_err_t keypad_start(keypad_pin_callback_t callback)
+{
+    s_callback = callback;
+    BaseType_t res = xTaskCreate(keypad_task, "keypad_task", 4096, NULL, 5, &s_task_handle);
+    if (res != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create keypad task");
+        return ESP_FAIL;
+    }
+    ESP_LOGI(TAG, "Keypad task started");
+    return ESP_OK;
+}
+
+void keypad_stop(void)
+{
+    if (s_task_handle) {
+        vTaskDelete(s_task_handle);
+        s_task_handle = NULL;
+        ESP_LOGI(TAG, "Keypad stopped");
+    }
+}

--- a/components/pin_auth/CMakeLists.txt
+++ b/components/pin_auth/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "pin_auth.c"
     INCLUDE_DIRS "include"
-    REQUIRES api_client
+    REQUIRES esp_http_client esp-tls freertos
 )

--- a/components/pin_auth/include/pin_auth.h
+++ b/components/pin_auth/include/pin_auth.h
@@ -1,4 +1,9 @@
 #pragma once
 
-// Pin_auth module
-// TODO: declare public API
+#include "esp_err.h"
+#include <stdbool.h>
+
+typedef void (*pin_auth_result_callback_t)(bool accepted);
+
+esp_err_t pin_auth_init(const char *base_url);
+esp_err_t pin_auth_verify(const char *hardware_uuid, const char *pin, pin_auth_result_callback_t callback);

--- a/components/pin_auth/pin_auth.c
+++ b/components/pin_auth/pin_auth.c
@@ -1,6 +1,74 @@
 #include "pin_auth.h"
+#include "esp_http_client.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include <string.h>
+#include <stdio.h>
 
 static const char *TAG = "PIN_AUTH";
 
-// TODO: implement pin_auth module
+#define PIN_AUTH_TIMEOUT_MS  8000
+#define PIN_AUTH_MAX_RETRIES 2
+
+static char s_base_url[128] = {0};
+
+esp_err_t pin_auth_init(const char *base_url)
+{
+    strncpy(s_base_url, base_url, sizeof(s_base_url) - 1);
+    ESP_LOGI(TAG, "PIN auth initialized. Base URL: %s", s_base_url);
+    return ESP_OK;
+}
+
+esp_err_t pin_auth_verify(const char *hardware_uuid, const char *pin, pin_auth_result_callback_t callback)
+{
+    char url[192];
+    snprintf(url, sizeof(url), "%s/devices/verify-pin", s_base_url);
+
+    char body[256];
+    snprintf(body, sizeof(body),
+             "{\"hardware_uuid\":\"%s\",\"pin\":\"%s\"}",
+             hardware_uuid, pin);
+
+    ESP_LOGI(TAG, "Verifying PIN for device: %s", hardware_uuid);
+
+    esp_http_client_config_t config = {
+        .url = url,
+        .method = HTTP_METHOD_POST,
+        .timeout_ms = PIN_AUTH_TIMEOUT_MS,
+        .skip_cert_common_name_check = true,
+    };
+
+    for (int attempt = 1; attempt <= PIN_AUTH_MAX_RETRIES; attempt++) {
+        esp_http_client_handle_t client = esp_http_client_init(&config);
+        if (!client) {
+            continue;
+        }
+
+        esp_http_client_set_header(client, "Content-Type", "application/json");
+        esp_http_client_set_post_field(client, body, strlen(body));
+
+        esp_err_t ret = esp_http_client_perform(client);
+        int status = esp_http_client_get_status_code(client);
+        esp_http_client_cleanup(client);
+
+        if (ret == ESP_OK) {
+            if (status == 200) {
+                ESP_LOGI(TAG, "PIN accepted");
+                if (callback) callback(true);
+                return ESP_OK;
+            } else if (status == 401 || status == 403) {
+                ESP_LOGW(TAG, "PIN denied (HTTP %d)", status);
+                if (callback) callback(false);
+                return ESP_OK;
+            }
+        }
+
+        ESP_LOGW(TAG, "Attempt %d/%d failed", attempt, PIN_AUTH_MAX_RETRIES);
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+
+    ESP_LOGE(TAG, "PIN verification failed");
+    if (callback) callback(false);
+    return ESP_FAIL;
+}

--- a/components/solenoid/CMakeLists.txt
+++ b/components/solenoid/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "solenoid.c"
     INCLUDE_DIRS "include"
-    REQUIRES driver
+    REQUIRES driver freertos
 )

--- a/components/solenoid/include/solenoid.h
+++ b/components/solenoid/include/solenoid.h
@@ -1,4 +1,12 @@
 #pragma once
 
-// Solenoid module
-// TODO: declare public API
+#include "esp_err.h"
+#include <stdbool.h>
+
+#define SOLENOID_UNLOCK_GPIO  13
+#define SOLENOID_UNLOCK_MS    5000
+
+esp_err_t solenoid_init(void);
+esp_err_t solenoid_unlock(void);
+esp_err_t solenoid_lock(void);
+bool solenoid_is_locked(void);

--- a/components/solenoid/solenoid.c
+++ b/components/solenoid/solenoid.c
@@ -1,6 +1,57 @@
 #include "solenoid.h"
+#include "driver/gpio.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 static const char *TAG = "SOLENOID";
+static bool s_locked = true;
 
-// TODO: implement solenoid module
+esp_err_t solenoid_init(void)
+{
+    gpio_config_t io_conf = {
+        .pin_bit_mask = (1ULL << SOLENOID_UNLOCK_GPIO),
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    esp_err_t ret = gpio_config(&io_conf);
+    if (ret != ESP_OK) return ret;
+    gpio_set_level(SOLENOID_UNLOCK_GPIO, 0);
+    s_locked = true;
+    ESP_LOGI(TAG, "Solenoid initialized (GPIO%d)", SOLENOID_UNLOCK_GPIO);
+    return ESP_OK;
+}
+
+static void auto_lock_task(void *arg)
+{
+    (void)arg;
+    vTaskDelay(pdMS_TO_TICKS(SOLENOID_UNLOCK_MS));
+    gpio_set_level(SOLENOID_UNLOCK_GPIO, 0);
+    s_locked = true;
+    ESP_LOGI(TAG, "Solenoid auto-locked after %dms", SOLENOID_UNLOCK_MS);
+    vTaskDelete(NULL);
+}
+
+esp_err_t solenoid_unlock(void)
+{
+    gpio_set_level(SOLENOID_UNLOCK_GPIO, 1);
+    s_locked = false;
+    ESP_LOGI(TAG, "Solenoid UNLOCKED (auto-locks in %dms)", SOLENOID_UNLOCK_MS);
+    xTaskCreate(auto_lock_task, "solenoid_lock", 2048, NULL, 5, NULL);
+    return ESP_OK;
+}
+
+esp_err_t solenoid_lock(void)
+{
+    gpio_set_level(SOLENOID_UNLOCK_GPIO, 0);
+    s_locked = true;
+    ESP_LOGI(TAG, "Solenoid LOCKED");
+    return ESP_OK;
+}
+
+bool solenoid_is_locked(void)
+{
+    return s_locked;
+}


### PR DESCRIPTION
## Summary
Implements keypad matrix scanning, PIN verification via API, solenoid lock control, and buzzer feedback.

## Type
- [x] `feat` — new feature

## Component(s) Affected
`keypad`, `pin_auth`, `solenoid`, `buzzer`

## Related Phase
Phase 6 — Keypad + PIN Auth

## Changes
- `keypad`: 3x4 matrix scan (GPIO21-32), # submit, * clear, 10s timeout, 8-digit max
- `pin_auth`: POST `/devices/verify-pin` with `hardware_uuid` + `pin`, retry x2
- `solenoid`: GPIO13 MOSFET gate, unlock for 5s then auto-lock, `solenoid_is_locked()` for tamper
- `buzzer`: GPIO12 MOSFET gate, short beep (deny), alarm start/stop (tamper)

## Testing
- [x] Built successfully (`idf.py build`)
- [ ] Tested on real ESP32 hardware
- [ ] Relevant section in `HARDWARE_TESTS.md` checked off

## Flash Size Impact
- Before: ~84% free
- After: ~84% free

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Buzzer control: initialization and alarm management with configurable beep functionality
  * Keypad input: PIN digit collection with callback-based submission handling
  * PIN verification: HTTP-based authentication with automatic retry and timeout management
  * Electronic lock: solenoid-based unlock/lock control with automatic re-locking timer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->