### PR TITLE
feat(ws): Phase 10 - WebSocket client for server-to-device commands

### DIFF
--- a/components/ws_client/CMakeLists.txt
+++ b/components/ws_client/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
     SRCS "ws_client.c"
     INCLUDE_DIRS "include"
+    REQUIRES solenoid buzzer freertos
 )

--- a/components/ws_client/include/ws_client.h
+++ b/components/ws_client/include/ws_client.h
@@ -1,4 +1,7 @@
 #pragma once
 
-// Ws_client module
-// TODO: declare public API
+#include "esp_err.h"
+
+esp_err_t ws_client_init(const char *base_url, const char *hardware_uuid);
+esp_err_t ws_client_start(void);
+void ws_client_stop(void);

--- a/components/ws_client/ws_client.c
+++ b/components/ws_client/ws_client.c
@@ -1,6 +1,158 @@
 #include "ws_client.h"
+#include "buzzer.h"
+#include "solenoid.h"
+#include "esp_websocket_client.h"
 #include "esp_log.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
 
 static const char *TAG = "WS_CLIENT";
 
-// TODO: implement ws_client module
+#define WS_URL_MAX_LEN      256
+#define WS_RECONNECT_MS     5000
+
+static esp_websocket_client_handle_t s_client = NULL;
+static char s_ws_url[WS_URL_MAX_LEN] = {0};
+
+static bool contains_token(const char *data, int len, const char *token)
+{
+    size_t token_len = strlen(token);
+
+    if (!data || len <= 0 || token_len == 0 || (size_t)len < token_len) {
+        return false;
+    }
+
+    for (int i = 0; i <= len - (int)token_len; i++) {
+        if (memcmp(data + i, token, token_len) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// Build WebSocket URL from base_url (http->ws, https->wss)
+static void build_ws_url(const char *base_url, const char *hardware_uuid, char *out, size_t out_len)
+{
+    char proto_replaced[WS_URL_MAX_LEN] = {0};
+
+    if (strncmp(base_url, "https://", 8) == 0) {
+        snprintf(proto_replaced, sizeof(proto_replaced), "wss://%s", base_url + 8);
+    } else if (strncmp(base_url, "http://", 7) == 0) {
+        snprintf(proto_replaced, sizeof(proto_replaced), "ws://%s", base_url + 7);
+    } else {
+        strncpy(proto_replaced, base_url, sizeof(proto_replaced) - 1);
+    }
+
+    snprintf(out, out_len, "%s/devices/ws?hardware_uuid=%s", proto_replaced, hardware_uuid);
+}
+
+static void handle_command(const char *data, int len)
+{
+    // Simple JSON command parsing: look for known command tokens.
+    if (contains_token(data, len, "remote_unlock")) {
+        ESP_LOGI(TAG, "Command: remote_unlock - unlocking vault");
+        solenoid_unlock();
+    } else if (contains_token(data, len, "buzzer_off")) {
+        ESP_LOGI(TAG, "Command: buzzer_off - stopping alarm");
+        buzzer_alarm_stop();
+    } else {
+        ESP_LOGW(TAG, "Unknown command: %.*s", len, data);
+    }
+}
+
+static void ws_event_handler(void *handler_args, esp_event_base_t base,
+                             int32_t event_id, void *event_data)
+{
+    (void)handler_args;
+    (void)base;
+    esp_websocket_event_data_t *data = (esp_websocket_event_data_t *)event_data;
+
+    switch (event_id) {
+        case WEBSOCKET_EVENT_CONNECTED:
+            ESP_LOGI(TAG, "WebSocket connected");
+            break;
+        case WEBSOCKET_EVENT_DISCONNECTED:
+            ESP_LOGW(TAG, "WebSocket disconnected - auto reconnect active");
+            break;
+        case WEBSOCKET_EVENT_DATA:
+            if (data && data->data_len > 0 && data->data_ptr) {
+                ESP_LOGI(TAG, "WS data received (%d bytes)", data->data_len);
+                handle_command(data->data_ptr, data->data_len);
+            }
+            break;
+        case WEBSOCKET_EVENT_ERROR:
+            ESP_LOGE(TAG, "WebSocket error");
+            break;
+        default:
+            break;
+    }
+}
+
+esp_err_t ws_client_init(const char *base_url, const char *hardware_uuid)
+{
+    if (!base_url || !hardware_uuid || strlen(base_url) == 0 || strlen(hardware_uuid) == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    build_ws_url(base_url, hardware_uuid, s_ws_url, sizeof(s_ws_url));
+    ESP_LOGI(TAG, "WebSocket URL: %s", s_ws_url);
+    return ESP_OK;
+}
+
+esp_err_t ws_client_start(void)
+{
+    if (s_ws_url[0] == '\0') {
+        ESP_LOGE(TAG, "WebSocket URL not initialized");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (s_client) {
+        ESP_LOGW(TAG, "WebSocket client already started");
+        return ESP_OK;
+    }
+
+    esp_websocket_client_config_t ws_cfg = {
+        .uri = s_ws_url,
+        .reconnect_timeout_ms = WS_RECONNECT_MS,
+        .skip_cert_common_name_check = true,
+    };
+
+    s_client = esp_websocket_client_init(&ws_cfg);
+    if (!s_client) {
+        ESP_LOGE(TAG, "Failed to init WebSocket client");
+        return ESP_FAIL;
+    }
+
+    esp_err_t ret = esp_websocket_register_events(s_client, WEBSOCKET_EVENT_ANY, ws_event_handler, NULL);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register WebSocket events: %s", esp_err_to_name(ret));
+        esp_websocket_client_destroy(s_client);
+        s_client = NULL;
+        return ret;
+    }
+
+    ret = esp_websocket_client_start(s_client);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to start WebSocket client: %s", esp_err_to_name(ret));
+        esp_websocket_client_destroy(s_client);
+        s_client = NULL;
+        return ret;
+    }
+
+    ESP_LOGI(TAG, "WebSocket client started");
+    return ESP_OK;
+}
+
+void ws_client_stop(void)
+{
+    if (!s_client) {
+        return;
+    }
+
+    esp_websocket_client_stop(s_client);
+    esp_websocket_client_destroy(s_client);
+    s_client = NULL;
+    ESP_LOGI(TAG, "WebSocket client stopped");
+}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,4 +1,16 @@
 idf_component_register(
     SRCS "main.c"
     INCLUDE_DIRS "."
+    REQUIRES
+        nvs_storage
+        wifi_manager
+        nfc
+        provisioning
+        api_client
+        keypad
+        pin_auth
+        solenoid
+        buzzer
+        tamper
+        ws_client
 )

--- a/main/main.c
+++ b/main/main.c
@@ -1,12 +1,153 @@
 #include <stdio.h>
+#include <string.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_log.h"
+#include "esp_event.h"
+#include "esp_netif.h"
+#include "esp_wifi.h"
+
+#include "nvs_storage.h"
+#include "wifi_manager.h"
+#include "nfc.h"
+#include "provisioning.h"
+#include "api_client.h"
+#include "keypad.h"
+#include "pin_auth.h"
+#include "solenoid.h"
+#include "buzzer.h"
+#include "tamper.h"
+#include "ws_client.h"
 
 static const char *TAG = "MAIN";
+
+#ifndef CONFIG_API_BASE_URL
+#define CONFIG_API_BASE_URL "http://localhost:3000"
+#endif
+
+#define WIFI_SSID_MAX_LEN   64
+#define WIFI_PASS_MAX_LEN   64
+#define API_URL_MAX_LEN     128
+#define NFC_UID_MAX_LEN     11
+#define HW_UUID_MAX_LEN     32
+
+static char s_hw_uuid[HW_UUID_MAX_LEN] = {0};
+static char s_api_url[API_URL_MAX_LEN] = {0};
+
+static void generate_hardware_uuid(char *uuid, size_t len) {
+    uint8_t mac[6];
+    esp_wifi_get_mac(WIFI_IF_STA, mac);
+    snprintf(uuid, len, "ESP32-%02X%02X%02X%02X%02X%02X",
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
+static void on_pin_auth_result(bool accepted) {
+    if (accepted) {
+        ESP_LOGI(TAG, "PIN accepted — unlocking vault");
+        solenoid_unlock();
+    } else {
+        ESP_LOGW(TAG, "PIN denied — buzzer feedback");
+        buzzer_beep_short();
+    }
+}
+
+static void on_pin_entered(const char *pin) {
+    ESP_LOGI(TAG, "PIN entered, verifying...");
+    pin_auth_verify(s_hw_uuid, pin, on_pin_auth_result);
+}
+
+static void run_normal_mode(void) {
+    ESP_LOGI(TAG, "Entering normal mode...");
+    ESP_ERROR_CHECK(solenoid_init());
+    ESP_ERROR_CHECK(buzzer_init());
+    ESP_ERROR_CHECK(keypad_init());
+    pin_auth_init(s_api_url);
+    ESP_ERROR_CHECK(keypad_start(on_pin_entered));
+    ESP_ERROR_CHECK(tamper_init(s_hw_uuid, s_api_url));
+    ESP_ERROR_CHECK(tamper_start());
+    ESP_ERROR_CHECK(ws_client_init(s_api_url, s_hw_uuid));
+    ESP_ERROR_CHECK(ws_client_start());
+    ESP_LOGI(TAG, "Normal mode active. System fully operational.");
+}
+
+static void on_provisioning_done(const provisioning_data_t *data) {
+    ESP_LOGI(TAG, "Provisioning complete. Saving data...");
+    nvs_storage_save_wifi(data->ssid, data->password);
+    nvs_storage_save_provisioning_token(data->token);
+    if (strlen(data->api_url) > 0) {
+        nvs_storage_save_api_url(data->api_url);
+    }
+    provisioning_stop();
+    ESP_ERROR_CHECK(wifi_manager_init());
+    esp_err_t ret = wifi_manager_connect(data->ssid, data->password);
+    if (ret != ESP_OK) { ESP_LOGE(TAG, "WiFi connection failed after provisioning"); return; }
+    ret = nvs_storage_load_api_url(s_api_url, sizeof(s_api_url));
+    if (ret != ESP_OK || strlen(s_api_url) == 0) {
+        strncpy(s_api_url, CONFIG_API_BASE_URL, sizeof(s_api_url) - 1);
+    }
+    api_client_init(s_api_url);
+    generate_hardware_uuid(s_hw_uuid, sizeof(s_hw_uuid));
+    nvs_storage_save_hardware_uuid(s_hw_uuid);
+    ret = api_client_register_device(s_hw_uuid, data->token);
+    if (ret != ESP_OK) { ESP_LOGE(TAG, "Device registration failed"); return; }
+    nvs_storage_set_provisioned(true);
+    ESP_LOGI(TAG, "Device registered and provisioned successfully.");
+    run_normal_mode();
+}
+
+static void on_nfc_card_tapped(const char *uid) {
+    ESP_LOGI(TAG, "NFC card tapped: %s", uid);
+    char stored_uid[NFC_UID_MAX_LEN] = {0};
+    esp_err_t ret = nvs_storage_load_nfc_uid(stored_uid, sizeof(stored_uid));
+    if (ret != ESP_OK || strlen(stored_uid) == 0) {
+        ESP_LOGI(TAG, "No stored UID. Saving and starting provisioning...");
+        nvs_storage_save_nfc_uid(uid);
+        nfc_stop_listener();
+        provisioning_start(on_provisioning_done);
+    } else if (strcmp(uid, stored_uid) == 0) {
+        ESP_LOGI(TAG, "UID matched. Starting re-provisioning...");
+        nvs_storage_set_provisioned(false);
+        nfc_stop_listener();
+        provisioning_start(on_provisioning_done);
+    } else {
+        ESP_LOGW(TAG, "Unknown card UID: %s. Ignoring.", uid);
+    }
+}
 
 void app_main(void)
 {
     ESP_LOGI(TAG, "smrtvlt firmware booting...");
-    // TODO: initialize modules and run state machine
+    ESP_ERROR_CHECK(nvs_storage_init());
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+    ESP_ERROR_CHECK(nfc_init());
+
+    if (!nvs_storage_is_provisioned()) {
+        ESP_LOGI(TAG, "Device not provisioned. Waiting for NFC tap...");
+        ESP_ERROR_CHECK(nfc_start_listener(on_nfc_card_tapped));
+        return;
+    }
+
+    ESP_LOGI(TAG, "Device provisioned. Loading credentials...");
+    char ssid[WIFI_SSID_MAX_LEN] = {0};
+    char password[WIFI_PASS_MAX_LEN] = {0};
+    esp_err_t ret = nvs_storage_load_wifi(ssid, sizeof(ssid), password, sizeof(password));
+    if (ret != ESP_OK) { ESP_LOGE(TAG, "Failed to load WiFi credentials"); return; }
+    ret = nvs_storage_load_api_url(s_api_url, sizeof(s_api_url));
+    if (ret != ESP_OK || strlen(s_api_url) == 0) {
+        strncpy(s_api_url, CONFIG_API_BASE_URL, sizeof(s_api_url) - 1);
+        ESP_LOGI(TAG, "Using default API URL: %s", s_api_url);
+    } else {
+        ESP_LOGI(TAG, "Using NVS API URL: %s", s_api_url);
+    }
+    ret = nvs_storage_load_hardware_uuid(s_hw_uuid, sizeof(s_hw_uuid));
+    if (ret != ESP_OK || strlen(s_hw_uuid) == 0) {
+        generate_hardware_uuid(s_hw_uuid, sizeof(s_hw_uuid));
+    }
+    api_client_init(s_api_url);
+    ESP_ERROR_CHECK(wifi_manager_init());
+    ret = wifi_manager_connect(ssid, password);
+    if (ret != ESP_OK) { ESP_LOGE(TAG, "WiFi connection failed"); return; }
+    ESP_LOGI(TAG, "System ready. API: %s", s_api_url);
+    run_normal_mode();
 }


### PR DESCRIPTION
## Summary
Implements WebSocket client for receiving real-time commands from the API (remote unlock, buzzer off). Also wires all normal mode modules in main.c — firmware is now fully implemented.

## Type
- [x] `feat` — new feature

## Component(s) Affected
`ws_client`, `main`

## Related Phase
Phase 10 — WebSocket Client

## Changes
- Auto-convert `http/https` base URL to `ws/wss`
- Connect to `{base_url}/devices/ws?hardware_uuid={uuid}`
- Handle `remote_unlock` → `solenoid_unlock()`
- Handle `buzzer_off` → `buzzer_alarm_stop()`
- Auto-reconnect every 5s on disconnect
- `main.c`: all modules wired — system fully operational

## Testing
- [x] Built successfully (`idf.py build`)
- [ ] Tested on real ESP32 hardware
- [ ] Relevant section in `HARDWARE_TESTS.md` checked off

## Flash Size Impact
- Before: ~84% free
- After: ~84% free