### PR TITLE
feat: provisioning portal — SoftAP, captive portal, NVS, WiFi manager

### DIFF
--- a/components/nfc/nfc.c
+++ b/components/nfc/nfc.c
@@ -62,7 +62,7 @@ esp_err_t nfc_start_listener(nfc_callback_t callback)
 {
     s_callback = callback;
     if (s_task_handle == NULL) {
-        xTaskCreate(nfc_button_task, "nfc_button_task", 2048, NULL, 5, &s_task_handle);
+        xTaskCreate(nfc_button_task, "nfc_button_task", 4096, NULL, 5, &s_task_handle);
     }
     ESP_LOGI(TAG, "NFC listener started");
     return ESP_OK;

--- a/components/nfc/nfc.c
+++ b/components/nfc/nfc.c
@@ -1,11 +1,59 @@
+// TODO: Replace with real UART NFC reader once hardware is available.
+// BOOT button (GPIO0) is used as a temporary provisioning trigger.
 #include "nfc.h"
 #include "esp_log.h"
+#include "driver/gpio.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 static const char *TAG = "NFC";
+#define NFC_TRIGGER_GPIO GPIO_NUM_0
+
 static nfc_callback_t s_callback;
+static TaskHandle_t s_task_handle = NULL;
+
+static void nfc_button_task(void *arg)
+{
+    const char *fake_uid = "BUTTON-TRIGGER";
+
+    while (true) {
+        if (s_callback == NULL) {
+            break;
+        }
+
+        if (gpio_get_level(NFC_TRIGGER_GPIO) == 0) {
+            vTaskDelay(pdMS_TO_TICKS(50));
+            if (s_callback == NULL) {
+                break;
+            }
+            if (gpio_get_level(NFC_TRIGGER_GPIO) == 0) {
+                s_callback(fake_uid);
+                while (gpio_get_level(NFC_TRIGGER_GPIO) == 0) {
+                    if (s_callback == NULL) {
+                        break;
+                    }
+                    vTaskDelay(pdMS_TO_TICKS(50));
+                }
+            }
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(100));
+    }
+
+    s_task_handle = NULL;
+    vTaskDelete(NULL);
+}
 
 esp_err_t nfc_init(void)
 {
+    gpio_config_t io_conf = {
+        .pin_bit_mask = 1ULL << NFC_TRIGGER_GPIO,
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE
+    };
+    gpio_config(&io_conf);
     ESP_LOGI(TAG, "NFC initialized");
     return ESP_OK;
 }
@@ -13,6 +61,9 @@ esp_err_t nfc_init(void)
 esp_err_t nfc_start_listener(nfc_callback_t callback)
 {
     s_callback = callback;
+    if (s_task_handle == NULL) {
+        xTaskCreate(nfc_button_task, "nfc_button_task", 2048, NULL, 5, &s_task_handle);
+    }
     ESP_LOGI(TAG, "NFC listener started");
     return ESP_OK;
 }

--- a/components/nvs_storage/include/nvs_storage.h
+++ b/components/nvs_storage/include/nvs_storage.h
@@ -21,3 +21,5 @@ esp_err_t nvs_storage_load_hardware_uuid(char *uuid, size_t uuid_len);
 
 esp_err_t nvs_storage_save_nfc_uid(const char *uid);
 esp_err_t nvs_storage_load_nfc_uid(char *uid, size_t uid_len);
+
+esp_err_t nvs_storage_erase_all(void);

--- a/components/nvs_storage/nvs_storage.c
+++ b/components/nvs_storage/nvs_storage.c
@@ -1,120 +1,211 @@
 #include "nvs_storage.h"
 #include "esp_log.h"
-#include <string.h>
+#include "nvs.h"
+#include "nvs_flash.h"
 
 static const char *TAG = "NVS_STORAGE";
 
-#define MAX_SSID_LEN     64
-#define MAX_PASS_LEN     64
-#define MAX_TOKEN_LEN    128
-#define MAX_API_URL_LEN  128
-#define MAX_UUID_LEN     32
-#define MAX_UID_LEN      11
+#define NVS_NAMESPACE "smrtvlt"
+#define KEY_WIFI_SSID "wifi_ssid"
+#define KEY_WIFI_PASS "wifi_pass"
+#define KEY_PROV_TOKEN "prov_token"
+#define KEY_API_URL "api_url"
+#define KEY_HW_UUID "hw_uuid"
+#define KEY_NFC_UID "nfc_uid"
+#define KEY_PROVISIONED "provisioned"
 
 static bool s_initialized;
-static bool s_provisioned;
-static char s_ssid[MAX_SSID_LEN] = {0};
-static char s_password[MAX_PASS_LEN] = {0};
-static char s_token[MAX_TOKEN_LEN] = {0};
-static char s_api_url[MAX_API_URL_LEN] = {0};
-static char s_uuid[MAX_UUID_LEN] = {0};
-static char s_uid[MAX_UID_LEN] = {0};
 
-static esp_err_t copy_out(char *dst, size_t dst_len, const char *src)
+static esp_err_t nvs_set_string(const char *key, const char *value)
 {
-    if (!dst || !src || dst_len == 0) {
-        return ESP_ERR_INVALID_ARG;
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open NVS (key=%s): %s", key, esp_err_to_name(ret));
+        return ret;
     }
-    if (src[0] == '\0') {
-        return ESP_ERR_NOT_FOUND;
+
+    ret = nvs_set_str(handle, key, value);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set NVS string (key=%s): %s", key, esp_err_to_name(ret));
+        goto cleanup;
     }
-    strncpy(dst, src, dst_len - 1);
-    dst[dst_len - 1] = '\0';
-    return ESP_OK;
+
+    ret = nvs_commit(handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to commit NVS (key=%s): %s", key, esp_err_to_name(ret));
+        goto cleanup;
+    }
+
+    ESP_LOGI(TAG, "Saved NVS string (key=%s)", key);
+
+cleanup:
+    nvs_close(handle);
+    return ret;
 }
 
-static esp_err_t copy_in(char *dst, size_t dst_len, const char *src)
+static esp_err_t nvs_get_string(const char *key, char *value, size_t value_len)
 {
-    if (!dst || !src || dst_len == 0) {
-        return ESP_ERR_INVALID_ARG;
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open NVS (key=%s): %s", key, esp_err_to_name(ret));
+        return ret;
     }
-    strncpy(dst, src, dst_len - 1);
-    dst[dst_len - 1] = '\0';
-    return ESP_OK;
+
+    ret = nvs_get_str(handle, key, value, &value_len);
+    if (ret == ESP_ERR_NVS_NOT_FOUND) {
+        ESP_LOGE(TAG, "NVS key not found (key=%s)", key);
+        ret = ESP_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to get NVS string (key=%s): %s", key, esp_err_to_name(ret));
+        goto cleanup;
+    }
+
+    ESP_LOGI(TAG, "Loaded NVS string (key=%s)", key);
+
+cleanup:
+    nvs_close(handle);
+    return ret;
 }
 
 esp_err_t nvs_storage_init(void)
 {
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_LOGE(TAG, "NVS init failed (%s), erasing", esp_err_to_name(ret));
+        ret = nvs_flash_erase();
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to erase NVS: %s", esp_err_to_name(ret));
+            return ret;
+        }
+        ret = nvs_flash_init();
+    }
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to init NVS: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
     s_initialized = true;
-    ESP_LOGI(TAG, "Initialized in-memory storage backend");
+    ESP_LOGI(TAG, "Initialized NVS storage backend");
     return ESP_OK;
 }
 
 bool nvs_storage_is_provisioned(void)
 {
-    return s_initialized && s_provisioned;
+    if (!s_initialized) {
+        return false;
+    }
+
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open NVS (key=%s): %s", KEY_PROVISIONED, esp_err_to_name(ret));
+        return false;
+    }
+
+    uint8_t value = 0;
+    ret = nvs_get_u8(handle, KEY_PROVISIONED, &value);
+    if (ret == ESP_ERR_NVS_NOT_FOUND) {
+        ESP_LOGE(TAG, "NVS key not found (key=%s)", KEY_PROVISIONED);
+        nvs_close(handle);
+        return false;
+    }
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to get NVS u8 (key=%s): %s", KEY_PROVISIONED, esp_err_to_name(ret));
+        nvs_close(handle);
+        return false;
+    }
+
+    nvs_close(handle);
+    ESP_LOGI(TAG, "Loaded provisioned flag: %u", value);
+    return value == 1;
 }
 
 esp_err_t nvs_storage_set_provisioned(bool provisioned)
 {
-    s_provisioned = provisioned;
-    return ESP_OK;
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open NVS (key=%s): %s", KEY_PROVISIONED, esp_err_to_name(ret));
+        return ret;
+    }
+
+    ret = nvs_set_u8(handle, KEY_PROVISIONED, provisioned ? 1 : 0);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set NVS u8 (key=%s): %s", KEY_PROVISIONED, esp_err_to_name(ret));
+        goto cleanup;
+    }
+
+    ret = nvs_commit(handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to commit NVS (key=%s): %s", KEY_PROVISIONED, esp_err_to_name(ret));
+        goto cleanup;
+    }
+
+    ESP_LOGI(TAG, "Saved provisioned flag: %u", provisioned ? 1 : 0);
+
+cleanup:
+    nvs_close(handle);
+    return ret;
 }
 
 esp_err_t nvs_storage_save_wifi(const char *ssid, const char *password)
 {
-    esp_err_t ret = copy_in(s_ssid, sizeof(s_ssid), ssid);
+    esp_err_t ret = nvs_set_string(KEY_WIFI_SSID, ssid);
     if (ret != ESP_OK) {
         return ret;
     }
-    return copy_in(s_password, sizeof(s_password), password);
+    return nvs_set_string(KEY_WIFI_PASS, password);
 }
 
 esp_err_t nvs_storage_load_wifi(char *ssid, size_t ssid_len, char *password, size_t password_len)
 {
-    esp_err_t ret = copy_out(ssid, ssid_len, s_ssid);
+    esp_err_t ret = nvs_get_string(KEY_WIFI_SSID, ssid, ssid_len);
     if (ret != ESP_OK) {
         return ret;
     }
-    return copy_out(password, password_len, s_password);
+    return nvs_get_string(KEY_WIFI_PASS, password, password_len);
 }
 
 esp_err_t nvs_storage_save_provisioning_token(const char *token)
 {
-    return copy_in(s_token, sizeof(s_token), token);
+    return nvs_set_string(KEY_PROV_TOKEN, token);
 }
 
 esp_err_t nvs_storage_load_provisioning_token(char *token, size_t token_len)
 {
-    return copy_out(token, token_len, s_token);
+    return nvs_get_string(KEY_PROV_TOKEN, token, token_len);
 }
 
 esp_err_t nvs_storage_save_api_url(const char *api_url)
 {
-    return copy_in(s_api_url, sizeof(s_api_url), api_url);
+    return nvs_set_string(KEY_API_URL, api_url);
 }
 
 esp_err_t nvs_storage_load_api_url(char *api_url, size_t api_url_len)
 {
-    return copy_out(api_url, api_url_len, s_api_url);
+    return nvs_get_string(KEY_API_URL, api_url, api_url_len);
 }
 
 esp_err_t nvs_storage_save_hardware_uuid(const char *uuid)
 {
-    return copy_in(s_uuid, sizeof(s_uuid), uuid);
+    return nvs_set_string(KEY_HW_UUID, uuid);
 }
 
 esp_err_t nvs_storage_load_hardware_uuid(char *uuid, size_t uuid_len)
 {
-    return copy_out(uuid, uuid_len, s_uuid);
+    return nvs_get_string(KEY_HW_UUID, uuid, uuid_len);
 }
 
 esp_err_t nvs_storage_save_nfc_uid(const char *uid)
 {
-    return copy_in(s_uid, sizeof(s_uid), uid);
+    return nvs_set_string(KEY_NFC_UID, uid);
 }
 
 esp_err_t nvs_storage_load_nfc_uid(char *uid, size_t uid_len)
 {
-    return copy_out(uid, uid_len, s_uid);
+    return nvs_get_string(KEY_NFC_UID, uid, uid_len);
 }

--- a/components/nvs_storage/nvs_storage.c
+++ b/components/nvs_storage/nvs_storage.c
@@ -209,3 +209,27 @@ esp_err_t nvs_storage_load_nfc_uid(char *uid, size_t uid_len)
 {
     return nvs_get_string(KEY_NFC_UID, uid, uid_len);
 }
+
+esp_err_t nvs_storage_erase_all(void)
+{
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open NVS for erase: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    ret = nvs_erase_all(handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to erase NVS: %s", esp_err_to_name(ret));
+        goto cleanup;
+    }
+    ret = nvs_commit(handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to commit NVS erase: %s", esp_err_to_name(ret));
+        goto cleanup;
+    }
+    ESP_LOGI(TAG, "NVS erased successfully");
+cleanup:
+    nvs_close(handle);
+    return ret;
+}

--- a/components/provisioning/CMakeLists.txt
+++ b/components/provisioning/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "provisioning.c"
     INCLUDE_DIRS "include"
-    REQUIRES esp_wifi esp_event esp_http_server esp_netif nvs_flash
+    REQUIRES esp_wifi esp_event esp_http_server esp_netif nvs_flash lwip
 )

--- a/components/provisioning/provisioning.c
+++ b/components/provisioning/provisioning.c
@@ -1,18 +1,304 @@
 #include "provisioning.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "esp_err.h"
+#include "esp_event.h"
+#include "esp_http_server.h"
 #include "esp_log.h"
+#include "esp_mac.h"
+#include "esp_netif.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 static const char *TAG = "PROVISIONING";
-static provisioning_done_callback_t s_callback;
+static provisioning_done_callback_t s_callback = NULL;
+static httpd_handle_t s_server = NULL;
+static esp_netif_t *s_ap_netif = NULL;
+
+typedef struct {
+    provisioning_done_callback_t callback;
+    provisioning_data_t data;
+} prov_stop_args_t;
+
+static const char *SETUP_HTML =
+    "<!DOCTYPE html>\n"
+    "<html>\n"
+    "<head><meta charset=\"UTF-8\"><title>SmartVault Setup</title>\n"
+    "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\n"
+    "<style>body{font-family:sans-serif;max-width:400px;margin:40px auto;padding:0 20px}"
+    "input{width:100%;padding:8px;margin:8px 0;box-sizing:border-box}"
+    "button{width:100%;padding:10px;background:#333;color:#fff;border:none;cursor:pointer}</style>\n"
+    "</head>\n"
+    "<body>\n"
+    "<h2>SmartVault Setup</h2>\n"
+    "<form method=\"POST\" action=\"/provision\">\n"
+    "<label>WiFi SSID<input name=\"ssid\" required></label>\n"
+    "<label>WiFi Password<input name=\"password\" type=\"password\"></label>\n"
+    "<label>Provisioning Token<input name=\"token\" required></label>\n"
+    "<label>API URL (optional)<input name=\"api_url\" placeholder=\"http://...\"></label>\n"
+    "<button type=\"submit\">Provision</button>\n"
+    "</form>\n"
+    "</body></html>\n";
+
+static int hex_char_to_int(char c)
+{
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    }
+    if (c >= 'a' && c <= 'f') {
+        return c - 'a' + 10;
+    }
+    if (c >= 'A' && c <= 'F') {
+        return c - 'A' + 10;
+    }
+    return -1;
+}
+
+static void url_decode(const char *src, char *dst, size_t dst_len)
+{
+    size_t si = 0;
+    size_t di = 0;
+
+    if (dst_len == 0) {
+        return;
+    }
+
+    while (src[si] != '\0' && di < dst_len - 1) {
+        if (src[si] == '+') {
+            dst[di++] = ' ';
+            si++;
+        } else if (src[si] == '%' && src[si + 1] != '\0' && src[si + 2] != '\0') {
+            int hi = hex_char_to_int(src[si + 1]);
+            int lo = hex_char_to_int(src[si + 2]);
+            if (hi >= 0 && lo >= 0) {
+                dst[di++] = (char)((hi << 4) | lo);
+                si += 3;
+            } else {
+                dst[di++] = src[si++];
+            }
+        } else {
+            dst[di++] = src[si++];
+        }
+    }
+
+    dst[di] = '\0';
+}
+
+static void parse_field(const char *body, const char *key, char *out, size_t out_len)
+{
+    size_t key_len = strlen(key);
+    const char *cursor = body;
+
+    if (out_len == 0) {
+        return;
+    }
+
+    out[0] = '\0';
+
+    while (*cursor != '\0') {
+        const char *amp = strchr(cursor, '&');
+        size_t pair_len = amp ? (size_t)(amp - cursor) : strlen(cursor);
+
+        if (pair_len > key_len + 1 && strncmp(cursor, key, key_len) == 0 && cursor[key_len] == '=') {
+            const char *value_start = cursor + key_len + 1;
+            size_t value_len = pair_len - key_len - 1;
+            char encoded[512];
+
+            if (value_len >= sizeof(encoded)) {
+                value_len = sizeof(encoded) - 1;
+            }
+
+            memcpy(encoded, value_start, value_len);
+            encoded[value_len] = '\0';
+            url_decode(encoded, out, out_len);
+            return;
+        }
+
+        if (amp == NULL) {
+            break;
+        }
+        cursor = amp + 1;
+    }
+}
+
+static esp_err_t root_get_handler(httpd_req_t *req)
+{
+    httpd_resp_set_type(req, "text/html");
+    return httpd_resp_send(req, SETUP_HTML, HTTPD_RESP_USE_STRLEN);
+}
+
+static void provisioning_stop_task(void *arg)
+{
+    prov_stop_args_t *args = (prov_stop_args_t *)arg;
+    provisioning_stop();
+    if (args->callback != NULL) {
+        args->callback(&args->data);
+    }
+    free(args);
+    vTaskDelete(NULL);
+}
+
+static esp_err_t provision_post_handler(httpd_req_t *req)
+{
+    char body[512];
+    int total_read = 0;
+    provisioning_data_t data = {0};
+
+    if (req->content_len <= 0 || req->content_len >= (int)sizeof(body)) {
+        httpd_resp_set_status(req, "400 Bad Request");
+        httpd_resp_send(req, "Invalid request body", HTTPD_RESP_USE_STRLEN);
+        return ESP_OK;
+    }
+
+    while (total_read < req->content_len) {
+        int ret = httpd_req_recv(req, body + total_read, req->content_len - total_read);
+        if (ret <= 0) {
+            if (ret == HTTPD_SOCK_ERR_TIMEOUT) {
+                continue;
+            }
+            ESP_LOGE(TAG, "Failed to receive provisioning body");
+            return ESP_FAIL;
+        }
+        total_read += ret;
+    }
+    body[total_read] = '\0';
+
+    parse_field(body, "ssid", data.ssid, sizeof(data.ssid));
+    parse_field(body, "password", data.password, sizeof(data.password));
+    parse_field(body, "token", data.token, sizeof(data.token));
+    parse_field(body, "api_url", data.api_url, sizeof(data.api_url));
+
+    if (data.ssid[0] == '\0' || data.token[0] == '\0') {
+        httpd_resp_set_status(req, "400 Bad Request");
+        httpd_resp_send(req, "Missing required fields: ssid and token", HTTPD_RESP_USE_STRLEN);
+        return ESP_OK;
+    }
+
+    httpd_resp_set_type(req, "text/html");
+    httpd_resp_send(req, "<h2>Provisioning complete. You may close this page.</h2>", HTTPD_RESP_USE_STRLEN);
+
+    if (s_callback != NULL) {
+        prov_stop_args_t *args = malloc(sizeof(prov_stop_args_t));
+        if (args != NULL) {
+            args->callback = s_callback;
+            args->data = data;
+            BaseType_t task_ok = xTaskCreate(provisioning_stop_task, "prov_stop", 8192, args,
+                                             tskIDLE_PRIORITY + 1, NULL);
+            if (task_ok != pdPASS) {
+                ESP_LOGE(TAG, "Failed to schedule provisioning stop task");
+                free(args);
+            }
+        } else {
+            ESP_LOGE(TAG, "Failed to allocate provisioning stop args");
+        }
+    }
+
+    return ESP_OK;
+}
 
 esp_err_t provisioning_start(provisioning_done_callback_t callback)
 {
+    uint8_t mac[6] = {0};
+    char ap_ssid[32] = {0};
+    wifi_config_t ap_config = {0};
+    httpd_config_t server_config = HTTPD_DEFAULT_CONFIG();
+
     s_callback = callback;
-    ESP_LOGI(TAG, "Provisioning started");
+
+    ESP_ERROR_CHECK(esp_netif_init());
+
+    esp_err_t event_err = esp_event_loop_create_default();
+    if (event_err != ESP_OK && event_err != ESP_ERR_INVALID_STATE) {
+        ESP_ERROR_CHECK(event_err);
+    }
+
+    esp_err_t wifi_init_err = esp_wifi_init(&(wifi_init_config_t)WIFI_INIT_CONFIG_DEFAULT());
+    if (wifi_init_err != ESP_OK && wifi_init_err != ESP_ERR_INVALID_STATE) {
+        ESP_ERROR_CHECK(wifi_init_err);
+    }
+
+    if (s_ap_netif == NULL) {
+        s_ap_netif = esp_netif_create_default_wifi_ap();
+        if (s_ap_netif == NULL) {
+            ESP_LOGE(TAG, "Failed to create AP netif");
+            return ESP_FAIL;
+        }
+    }
+
+    ESP_ERROR_CHECK(esp_read_mac(mac, ESP_MAC_WIFI_SOFTAP));
+    snprintf(ap_ssid, sizeof(ap_ssid), "SmartVault-%02X%02X%02X", mac[3], mac[4], mac[5]);
+
+    strncpy((char *)ap_config.ap.ssid, ap_ssid, sizeof(ap_config.ap.ssid) - 1);
+    ap_config.ap.ssid_len = (uint8_t)strlen(ap_ssid);
+    ap_config.ap.channel = 1;
+    ap_config.ap.authmode = WIFI_AUTH_OPEN;
+    ap_config.ap.max_connection = 4;
+
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP));
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &ap_config));
+    ESP_ERROR_CHECK(esp_wifi_start());
+
+    server_config.server_port = 80;
+    esp_err_t server_err = httpd_start(&s_server, &server_config);
+    if (server_err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to start HTTP server: %s", esp_err_to_name(server_err));
+        provisioning_stop();
+        return server_err;
+    }
+
+    httpd_uri_t root_uri = {
+        .uri = "/",
+        .method = HTTP_GET,
+        .handler = root_get_handler,
+        .user_ctx = NULL,
+    };
+
+    httpd_uri_t provision_uri = {
+        .uri = "/provision",
+        .method = HTTP_POST,
+        .handler = provision_post_handler,
+        .user_ctx = NULL,
+    };
+
+    ESP_ERROR_CHECK(httpd_register_uri_handler(s_server, &root_uri));
+    ESP_ERROR_CHECK(httpd_register_uri_handler(s_server, &provision_uri));
+
+    ESP_LOGI(TAG, "SoftAP started: %s", ap_ssid);
+    ESP_LOGI(TAG, "Captive portal ready at 192.168.4.1");
     return ESP_OK;
 }
 
 void provisioning_stop(void)
 {
+    if (s_server != NULL) {
+        esp_err_t err = httpd_stop(s_server);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "httpd_stop failed: %s", esp_err_to_name(err));
+        }
+        s_server = NULL;
+    }
+
+    esp_err_t wifi_stop_err = esp_wifi_stop();
+    if (wifi_stop_err != ESP_OK && wifi_stop_err != ESP_ERR_WIFI_NOT_INIT && wifi_stop_err != ESP_ERR_WIFI_NOT_STARTED) {
+        ESP_LOGE(TAG, "esp_wifi_stop failed: %s", esp_err_to_name(wifi_stop_err));
+    }
+
+    esp_err_t wifi_deinit_err = esp_wifi_deinit();
+    if (wifi_deinit_err != ESP_OK && wifi_deinit_err != ESP_ERR_WIFI_NOT_INIT) {
+        ESP_LOGE(TAG, "esp_wifi_deinit failed: %s", esp_err_to_name(wifi_deinit_err));
+    }
+
+    if (s_ap_netif != NULL) {
+        esp_netif_destroy(s_ap_netif);
+        s_ap_netif = NULL;
+    }
+
     s_callback = NULL;
     ESP_LOGI(TAG, "Provisioning stopped");
 }

--- a/components/provisioning/provisioning.c
+++ b/components/provisioning/provisioning.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/time.h>
 
 #include "esp_err.h"
 #include "esp_event.h"
@@ -15,11 +16,15 @@
 #include "esp_wifi.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "lwip/netdb.h"
+#include "lwip/sockets.h"
 
 static const char *TAG = "PROVISIONING";
 static provisioning_done_callback_t s_callback = NULL;
 static httpd_handle_t s_server = NULL;
 static esp_netif_t *s_ap_netif = NULL;
+static TaskHandle_t s_dns_task_handle = NULL;
+static volatile bool s_dns_running = false;
 
 typedef struct {
     provisioning_done_callback_t callback;
@@ -133,6 +138,142 @@ static esp_err_t root_get_handler(httpd_req_t *req)
     return httpd_resp_send(req, SETUP_HTML, HTTPD_RESP_USE_STRLEN);
 }
 
+static esp_err_t redirect_handler(httpd_req_t *req)
+{
+    httpd_resp_set_status(req, "302 Found");
+    httpd_resp_set_hdr(req, "Location", "http://192.168.4.1/");
+    httpd_resp_send(req, NULL, 0);
+    return ESP_OK;
+}
+
+static bool build_dns_response(const uint8_t *query, ssize_t query_len, uint8_t *response,
+                               size_t response_size, ssize_t *response_len)
+{
+    size_t question_end = 12;
+    size_t question_len = 0;
+    size_t answer_offset = 0;
+    const uint8_t answer_record[] = {
+        0xC0, 0x0C,
+        0x00, 0x01,
+        0x00, 0x01,
+        0x00, 0x00, 0x00, 0x0A,
+        0x00, 0x04,
+        192,  168,  4,    1,
+    };
+
+    if (query_len < 17 || response_size < sizeof(answer_record) + 12) {
+        return false;
+    }
+
+    while (question_end < (size_t)query_len && query[question_end] != 0x00) {
+        uint8_t label_len = query[question_end];
+        if (label_len == 0 || question_end + 1U + label_len > (size_t)query_len) {
+            return false;
+        }
+        question_end += 1U + label_len;
+    }
+
+    if (question_end + 5U > (size_t)query_len) {
+        return false;
+    }
+
+    question_end += 1U;
+    question_len = (question_end + 4U) - 12U;
+    answer_offset = 12U + question_len;
+
+    if (answer_offset + sizeof(answer_record) > response_size) {
+        return false;
+    }
+
+    memset(response, 0, response_size);
+    response[0] = query[0];
+    response[1] = query[1];
+    response[2] = 0x81;
+    response[3] = 0x80;
+    response[4] = 0x00;
+    response[5] = 0x01;
+    response[6] = 0x00;
+    response[7] = 0x01;
+    response[8] = 0x00;
+    response[9] = 0x00;
+    response[10] = 0x00;
+    response[11] = 0x00;
+
+    memcpy(response + 12, query + 12, question_len);
+    memcpy(response + answer_offset, answer_record, sizeof(answer_record));
+
+    *response_len = (ssize_t)(answer_offset + sizeof(answer_record));
+    return true;
+}
+
+static void dns_server_task(void *arg)
+{
+    (void)arg;
+    int sock = -1;
+    struct sockaddr_in listen_addr = {0};
+    struct timeval timeout = {
+        .tv_sec = 1,
+        .tv_usec = 0,
+    };
+
+    ESP_LOGI(TAG, "DNS server starting on UDP 53");
+
+    sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sock < 0) {
+        ESP_LOGE(TAG, "Failed to create DNS socket");
+        s_dns_task_handle = NULL;
+        vTaskDelete(NULL);
+        return;
+    }
+
+    if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) {
+        ESP_LOGE(TAG, "Failed to set DNS socket timeout");
+        close(sock);
+        s_dns_task_handle = NULL;
+        vTaskDelete(NULL);
+        return;
+    }
+
+    listen_addr.sin_family = AF_INET;
+    listen_addr.sin_port = htons(53);
+    listen_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    if (bind(sock, (struct sockaddr *)&listen_addr, sizeof(listen_addr)) < 0) {
+        ESP_LOGE(TAG, "Failed to bind DNS socket to port 53");
+        close(sock);
+        s_dns_task_handle = NULL;
+        vTaskDelete(NULL);
+        return;
+    }
+
+    while (s_dns_running) {
+        uint8_t query_buf[512] = {0};
+        uint8_t response_buf[512] = {0};
+        ssize_t query_len = 0;
+        ssize_t response_len = 0;
+        struct sockaddr_in source_addr = {0};
+        socklen_t source_addr_len = sizeof(source_addr);
+
+        query_len = recvfrom(sock, query_buf, sizeof(query_buf), 0, (struct sockaddr *)&source_addr,
+                             &source_addr_len);
+        if (query_len < 0) {
+            continue;
+        }
+
+        if (!build_dns_response(query_buf, query_len, response_buf, sizeof(response_buf), &response_len)) {
+            continue;
+        }
+
+        (void)sendto(sock, response_buf, (size_t)response_len, 0, (struct sockaddr *)&source_addr,
+                     source_addr_len);
+    }
+
+    close(sock);
+    ESP_LOGI(TAG, "DNS server stopped");
+    s_dns_task_handle = NULL;
+    vTaskDelete(NULL);
+}
+
 static void provisioning_stop_task(void *arg)
 {
     prov_stop_args_t *args = (prov_stop_args_t *)arg;
@@ -244,7 +385,20 @@ esp_err_t provisioning_start(provisioning_done_callback_t callback)
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &ap_config));
     ESP_ERROR_CHECK(esp_wifi_start());
 
+    s_dns_running = true;
+    BaseType_t dns_task_ok = xTaskCreate(dns_server_task, "dns_server", 4096, NULL, 5,
+                                         &s_dns_task_handle);
+    if (dns_task_ok != pdPASS) {
+        ESP_LOGE(TAG, "Failed to start DNS task");
+        s_dns_running = false;
+        provisioning_stop();
+        return ESP_FAIL;
+    }
+    ESP_LOGI(TAG, "DNS captive portal redirect enabled");
+
     server_config.server_port = 80;
+    server_config.max_uri_handlers = 8;
+    server_config.uri_match_fn = httpd_uri_match_wildcard;
     esp_err_t server_err = httpd_start(&s_server, &server_config);
     if (server_err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to start HTTP server: %s", esp_err_to_name(server_err));
@@ -266,8 +420,16 @@ esp_err_t provisioning_start(provisioning_done_callback_t callback)
         .user_ctx = NULL,
     };
 
+    httpd_uri_t redirect_uri = {
+        .uri = "/*",
+        .method = HTTP_GET,
+        .handler = redirect_handler,
+        .user_ctx = NULL,
+    };
+
     ESP_ERROR_CHECK(httpd_register_uri_handler(s_server, &root_uri));
     ESP_ERROR_CHECK(httpd_register_uri_handler(s_server, &provision_uri));
+    ESP_ERROR_CHECK(httpd_register_uri_handler(s_server, &redirect_uri));
 
     ESP_LOGI(TAG, "SoftAP started: %s", ap_ssid);
     ESP_LOGI(TAG, "Captive portal ready at 192.168.4.1");
@@ -276,6 +438,12 @@ esp_err_t provisioning_start(provisioning_done_callback_t callback)
 
 void provisioning_stop(void)
 {
+    s_dns_running = false;
+    if (s_dns_task_handle != NULL) {
+        vTaskDelay(pdMS_TO_TICKS(1500));
+        s_dns_task_handle = NULL;
+    }
+
     if (s_server != NULL) {
         esp_err_t err = httpd_stop(s_server);
         if (err != ESP_OK) {

--- a/components/wifi_manager/wifi_manager.c
+++ b/components/wifi_manager/wifi_manager.c
@@ -46,10 +46,16 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base, int32_t e
 
 esp_err_t wifi_manager_init(void)
 {
-    s_wifi_event_group = xEventGroupCreate();
-    if (s_wifi_event_group == NULL) {
-        ESP_LOGE(TAG, "Failed to create WiFi event group");
-        return ESP_ERR_NO_MEM;
+    ESP_LOGI(TAG, "WiFi manager initializing...");
+
+    if (s_wifi_event_group != NULL) {
+        xEventGroupClearBits(s_wifi_event_group, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT);
+    } else {
+        s_wifi_event_group = xEventGroupCreate();
+        if (s_wifi_event_group == NULL) {
+            ESP_LOGE(TAG, "Failed to create WiFi event group");
+            return ESP_ERR_NO_MEM;
+        }
     }
 
     esp_netif_create_default_wifi_sta();
@@ -74,13 +80,15 @@ esp_err_t wifi_manager_connect(const char *ssid, const char *password)
         return ESP_ERR_INVALID_ARG;
     }
 
+    ESP_LOGI(TAG, "Connecting to SSID=%s...", ssid);
+    s_retry_count = 0;
+
     wifi_config_t wifi_config;
     memset(&wifi_config, 0, sizeof(wifi_config));
     strncpy((char *)wifi_config.sta.ssid, ssid, sizeof(wifi_config.sta.ssid) - 1);
     strncpy((char *)wifi_config.sta.password, password, sizeof(wifi_config.sta.password) - 1);
 
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
-    ESP_ERROR_CHECK(esp_wifi_connect());
 
     EventBits_t bits = xEventGroupWaitBits(
         s_wifi_event_group,

--- a/components/wifi_manager/wifi_manager.c
+++ b/components/wifi_manager/wifi_manager.c
@@ -1,17 +1,103 @@
 #include "wifi_manager.h"
+#include "esp_event.h"
 #include "esp_log.h"
+#include "esp_netif.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
 #include <string.h>
 
 static const char *TAG = "WIFI_MANAGER";
 
+#define WIFI_CONNECTED_BIT BIT0
+#define WIFI_FAIL_BIT BIT1
+#define WIFI_MAX_RETRY 5
+
+static EventGroupHandle_t s_wifi_event_group;
+static int s_retry_count = 0;
+
+static void wifi_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data)
+{
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        ESP_LOGI(TAG, "WiFi STA start");
+        esp_wifi_connect();
+        return;
+    }
+
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        if (s_retry_count < WIFI_MAX_RETRY) {
+            s_retry_count++;
+            ESP_LOGI(TAG, "Retrying WiFi connection (%d/%d)", s_retry_count, WIFI_MAX_RETRY);
+            esp_wifi_connect();
+        } else {
+            ESP_LOGE(TAG, "WiFi connection failed after %d retries", WIFI_MAX_RETRY);
+            xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
+        }
+        return;
+    }
+
+    if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
+        ESP_LOGI(TAG, "Got IP: " IPSTR, IP2STR(&event->ip_info.ip));
+        s_retry_count = 0;
+        xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+    }
+}
+
 esp_err_t wifi_manager_init(void)
 {
+    s_wifi_event_group = xEventGroupCreate();
+    if (s_wifi_event_group == NULL) {
+        ESP_LOGE(TAG, "Failed to create WiFi event group");
+        return ESP_ERR_NO_MEM;
+    }
+
+    esp_netif_create_default_wifi_sta();
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+    ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler, NULL));
+
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    ESP_ERROR_CHECK(esp_wifi_start());
+
     ESP_LOGI(TAG, "WiFi manager initialized");
     return ESP_OK;
 }
 
 esp_err_t wifi_manager_connect(const char *ssid, const char *password)
 {
-    ESP_LOGI(TAG, "WiFi connect requested (ssid=%s, pass_len=%d)", ssid ? ssid : "", password ? (int)strlen(password) : 0);
-    return ESP_OK;
+    if (ssid == NULL || password == NULL) {
+        ESP_LOGE(TAG, "SSID or password is NULL");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    wifi_config_t wifi_config;
+    memset(&wifi_config, 0, sizeof(wifi_config));
+    strncpy((char *)wifi_config.sta.ssid, ssid, sizeof(wifi_config.sta.ssid) - 1);
+    strncpy((char *)wifi_config.sta.password, password, sizeof(wifi_config.sta.password) - 1);
+
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+    ESP_ERROR_CHECK(esp_wifi_connect());
+
+    EventBits_t bits = xEventGroupWaitBits(
+        s_wifi_event_group,
+        WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+        pdTRUE,
+        pdFALSE,
+        portMAX_DELAY);
+
+    if (bits & WIFI_CONNECTED_BIT) {
+        ESP_LOGI(TAG, "Connected to SSID=%s", ssid);
+        return ESP_OK;
+    }
+    if (bits & WIFI_FAIL_BIT) {
+        ESP_LOGE(TAG, "Failed to connect to SSID=%s", ssid);
+        return ESP_FAIL;
+    }
+
+    ESP_LOGE(TAG, "Unexpected WiFi event state");
+    return ESP_FAIL;
 }

--- a/components/wifi_manager/wifi_manager.c
+++ b/components/wifi_manager/wifi_manager.c
@@ -67,7 +67,6 @@ esp_err_t wifi_manager_init(void)
     ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler, NULL));
 
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
-    ESP_ERROR_CHECK(esp_wifi_start());
 
     ESP_LOGI(TAG, "WiFi manager initialized");
     return ESP_OK;
@@ -89,6 +88,7 @@ esp_err_t wifi_manager_connect(const char *ssid, const char *password)
     strncpy((char *)wifi_config.sta.password, password, sizeof(wifi_config.sta.password) - 1);
 
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+    ESP_ERROR_CHECK(esp_wifi_start());
 
     EventBits_t bits = xEventGroupWaitBits(
         s_wifi_event_group,

--- a/main/main.c
+++ b/main/main.c
@@ -77,7 +77,6 @@ static void on_provisioning_done(const provisioning_data_t *data) {
     if (strlen(data->api_url) > 0) {
         nvs_storage_save_api_url(data->api_url);
     }
-    provisioning_stop();
     ESP_ERROR_CHECK(wifi_manager_init());
     esp_err_t ret = wifi_manager_connect(data->ssid, data->password);
     if (ret != ESP_OK) { ESP_LOGE(TAG, "WiFi connection failed after provisioning"); return; }

--- a/main/main.c
+++ b/main/main.c
@@ -95,8 +95,19 @@ static void on_provisioning_done(const provisioning_data_t *data) {
     run_normal_mode();
 }
 
+// TODO: Remove BUTTON-TRIGGER handling once real NFC hardware is available.
 static void on_nfc_card_tapped(const char *uid) {
     ESP_LOGI(TAG, "NFC card tapped: %s", uid);
+
+    bool is_button_trigger = strcmp(uid, "BUTTON-TRIGGER") == 0;
+
+    if (is_button_trigger) {
+        ESP_LOGI(TAG, "Boot button pressed — triggering provisioning");
+        nfc_stop_listener();
+        provisioning_start(on_provisioning_done);
+        return;
+    }
+
     char stored_uid[NFC_UID_MAX_LEN] = {0};
     esp_err_t ret = nvs_storage_load_nfc_uid(stored_uid, sizeof(stored_uid));
     if (ret != ESP_OK || strlen(stored_uid) == 0) {

--- a/main/main.c
+++ b/main/main.c
@@ -6,6 +6,7 @@
 #include "esp_event.h"
 #include "esp_netif.h"
 #include "esp_wifi.h"
+#include "driver/gpio.h"
 
 #include "nvs_storage.h"
 #include "wifi_manager.h"
@@ -56,6 +57,33 @@ static void on_pin_entered(const char *pin) {
     pin_auth_verify(s_hw_uuid, pin, on_pin_auth_result);
 }
 
+// TODO: Remove once real NFC hardware is available.
+static void reprovision_button_task(void *arg)
+{
+    gpio_config_t io_conf = {
+        .pin_bit_mask = (1ULL << GPIO_NUM_0),
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    gpio_config(&io_conf);
+
+    ESP_LOGI("MAIN", "Re-provisioning button monitor active (GPIO0)");
+
+    while (1) {
+        if (gpio_get_level(GPIO_NUM_0) == 0) {
+            vTaskDelay(pdMS_TO_TICKS(50));
+            if (gpio_get_level(GPIO_NUM_0) == 0) {
+                ESP_LOGI("MAIN", "Boot button pressed in normal mode — erasing NVS and re-provisioning");
+                nvs_storage_erase_all();
+                esp_restart();
+            }
+        }
+        vTaskDelay(pdMS_TO_TICKS(100));
+    }
+}
+
 static void run_normal_mode(void) {
     ESP_LOGI(TAG, "Entering normal mode...");
     ESP_ERROR_CHECK(solenoid_init());
@@ -67,6 +95,8 @@ static void run_normal_mode(void) {
     ESP_ERROR_CHECK(tamper_start());
     ESP_ERROR_CHECK(ws_client_init(s_api_url, s_hw_uuid));
     ESP_ERROR_CHECK(ws_client_start());
+    // TODO: Remove once real NFC hardware is available.
+    xTaskCreate(reprovision_button_task, "reprov_btn", 2048, NULL, 5, NULL);
     ESP_LOGI(TAG, "Normal mode active. System fully operational.");
 }
 
@@ -101,7 +131,8 @@ static void on_nfc_card_tapped(const char *uid) {
     bool is_button_trigger = strcmp(uid, "BUTTON-TRIGGER") == 0;
 
     if (is_button_trigger) {
-        ESP_LOGI(TAG, "Boot button pressed — triggering provisioning");
+        ESP_LOGI(TAG, "Boot button pressed — erasing NVS and triggering provisioning");
+        nvs_storage_erase_all();
         nfc_stop_listener();
         provisioning_start(on_provisioning_done);
         return;

--- a/tasks.md
+++ b/tasks.md
@@ -1,7 +1,7 @@
 # SmartVault Firmware Task Roadmap
 
-1. Project setup and build scaffold.
-2. NVS storage and Wi-Fi manager.
+1. ✓ Project setup and build scaffold.
+2. ✓ NVS storage and Wi-Fi manager.
 3. NFC reader integration.
 4. Provisioning portal.
 5. Device registration API.
@@ -11,3 +11,17 @@
 9. Lock state machine and error handling.
 10. Integration testing on hardware.
 11. Production hardening and release prep.
+
+---
+
+## Notes
+
+### Hardware Availability
+- Only ESP32 board is available at this time.
+- NFC reader, keypad, solenoid, buzzer, and tamper sensor are not yet available.
+- Tasks 3, 6, 7 will be implemented but can only be fully tested once hardware is provided.
+
+### Temporary: Built-in Button for Provisioning Trigger
+- The ESP32 built-in button (GPIO0 / BOOT button) is used to trigger provisioning during development.
+- This replaces the NFC tap trigger until the NFC reader hardware is available.
+- **Must be removed and replaced with NFC trigger once hardware is provided.**


### PR DESCRIPTION
## Summary
- Implemented real NVS flash storage (replaces in-memory stubs)
- Implemented WiFi manager with STA mode, event handling, and retry logic
- Implemented provisioning portal: SoftAP (SmartVault-XXXXXX), HTTP captive portal at 192.168.4.1
- Added BOOT button (GPIO0) as temporary NFC trigger for provisioning (to be removed when NFC hardware is available)
- Verified full provisioning flow on hardware: SoftAP → form submit → NVS save → WiFi connect → normal mode boot

## Test Results
- Build: passing
- Flash: verified on ESP32
- Boot log confirmed: NVS init, SoftAP start, form submit, WiFi connected (IP assigned), normal mode active

## Notes
- API registration and WebSocket errors are expected — backend not yet deployed
- Tamper false alarm on GPIO34 is expected — hardware not yet connected